### PR TITLE
Colorspace fixing when creating new image size

### DIFF
--- a/photologue/models.py
+++ b/photologue/models.py
@@ -2,6 +2,7 @@ import os
 import random
 import shutil
 import zipfile
+import utils
 
 from datetime import datetime
 from inspect import isclass
@@ -424,6 +425,8 @@ class ImageModel(models.Model):
             im = Image.open(image_model_obj.image.path)
         except IOError:
             return
+        # Correct colorspace
+        im = utils.colorspace(im)
         # Save the original format
         im_format = im.format
         # Apply effect if found

--- a/photologue/utils/__init__.py
+++ b/photologue/utils/__init__.py
@@ -1,0 +1,61 @@
+# Required PIL classes may or may not be available from the root namespace
+# depending on the installation method used.
+try:
+    import Image
+except ImportError:
+    try:
+        from PIL import Image
+    except ImportError:
+        raise ImportError('Photologue was unable to import the Python Imaging Library. Please confirm it`s installed and available on your current Python path.')
+
+
+def is_transparent(image):
+    """
+    Check to see if an image is transparent.
+    """
+    if not isinstance(image, Image.Image):
+        # Can only deal with PIL images, fall back to the assumption that that
+        # it's not transparent.
+        return False
+    return (image.mode in ('RGBA', 'LA') or
+            (image.mode == 'P' and 'transparency' in image.info))
+
+
+def colorspace(im, bw=False, replace_alpha=False, **kwargs):
+    """
+    Convert images to the correct color space.
+
+    A passive option (i.e. always processed) of this method is that all images
+    (unless grayscale) are converted to RGB colorspace.
+
+    This processor should be listed before :func:`scale_and_crop` so palette is
+    changed before the image is resized.
+
+    bw
+        Make the thumbnail grayscale (not really just black & white).
+
+    replace_alpha
+        Replace any transparency layer with a solid color. For example,
+        ``replace_alpha='#fff'`` would replace the transparency layer with
+        white.
+
+    """
+    transparent = is_transparent(im)
+    if bw:
+        if im.mode in ('L', 'LA'):
+            return im
+        if is_transparent:
+            return im.convert('LA')
+        else:
+            return im.convert('L')
+    if im.mode in ('L', 'RGB'):
+        return im
+    if transparent:
+        if im.mode != 'RGBA':
+            im = im.convert('RGBA')
+        if not replace_alpha:
+            return im
+        base = Image.new('RGBA', im.size, replace_alpha)
+        base.paste(im)
+        im = base
+    return im.convert('RGB')


### PR DESCRIPTION
Currently an error occurs when you attempt to create a new image size from certain types of GIF images. The error states that it cannot write a mode P image object into a JPEG. The recommended solution for this is to convert a P mode image to an RGB one.

I've added something a little more extensive that I found in a snippet that takes care of even more scenarios.
