### PR TITLE
Simple fix to allow for timezone-enabled models in Django 1.4+

### DIFF
--- a/photologue/models.py
+++ b/photologue/models.py
@@ -5,6 +5,10 @@ import zipfile
 import utils
 
 from datetime import datetime
+try: 
+    from django.utils.timezone import now
+except ImportError:
+    from datetime.datetime import now
 from inspect import isclass
 
 from django.db import models
@@ -126,7 +130,7 @@ IMAGE_FILTERS_HELP_TEXT = _('Chain multiple filters using the following pattern 
 
 
 class Gallery(models.Model):
-    date_added = models.DateTimeField(_('date published'), default=datetime.now)
+    date_added = models.DateTimeField(_('date published'), default=now)
     title = models.CharField(_('title'), max_length=100, unique=True)
     title_slug = models.SlugField(_('title slug'), unique=True,
                                   help_text=_('A "slug" is a unique URL-friendly title for an object.'))
@@ -500,7 +504,7 @@ class ImageModel(models.Model):
             except:
                 pass
         if self.date_taken is None:
-            self.date_taken = datetime.now()
+            self.date_taken = now()
         if self._get_pk_val():
             self.clear_cache()
         super(ImageModel, self).save(*args, **kwargs)
@@ -530,7 +534,7 @@ class Photo(ImageModel):
     title_slug = models.SlugField(_('slug'), unique=True,
                                   help_text=('A "slug" is a unique URL-friendly title for an object.'))
     caption = models.TextField(_('caption'), blank=True)
-    date_added = models.DateTimeField(_('date added'), default=datetime.now, editable=False)
+    date_added = models.DateTimeField(_('date added'), default=now, editable=False)
     is_public = models.BooleanField(_('is public'), default=True, help_text=_('Public photographs will be displayed in the default views.'))
     tags = TagField(help_text=tagfield_help_text, verbose_name=_('tags'))
 


### PR DESCRIPTION
Simply changed the import of datetime to a try-catch for django's timezone utils, and called now() in the code accordingly, instead of datetime.now(). Ran tests for USE_TZ=False and USE_TZ=True, and they passed.
